### PR TITLE
feat: Add FullParseResponse model and handle_url_response function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reductoai"
-version = "0.2.0"
+version = "0.2.1"
 description = "The official Python library for the reducto API"
 dynamic = ["readme"]
 license = "Apache-2.0"

--- a/src/reducto/lib/helpers.py
+++ b/src/reducto/lib/helpers.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+import httpx
+from pydantic import BaseModel
+
+from reducto.types import ParseResponse
+from reducto.types.shared.parse_response import ParseUsage, ResultFullResult
+
+
+class FullParseResponse(BaseModel):
+    duration: float
+    """The duration of the parse request in seconds."""
+
+    job_id: str
+
+    result: ResultFullResult
+    """The full response from the document processing service."""
+
+    usage: ParseUsage
+
+    pdf_url: Optional[str] = None
+    """The storage URL of the converted PDF file."""
+
+
+def handle_url_response(response: ParseResponse) -> FullParseResponse:
+    if response.result.type == "url":
+        with httpx.stream("GET", response.result.url) as r:
+            result = ResultFullResult.model_validate_json(r.text)
+            return FullParseResponse(
+                duration=response.duration,
+                job_id=response.job_id,
+                result=result,
+                usage=response.usage,
+            )
+    else:
+        return FullParseResponse.model_validate(response.model_dump())


### PR DESCRIPTION
The changes introduce a new `FullParseResponse` model and a `handle_url_response` function in the `helpers.py` module. The `FullParseResponse` model represents the full response from the document processing service, including the duration, job ID, result, usage, and optional PDF URL. The `handle_url_response` function is responsible for handling the response when the result type is "url", by streaming the content and validating the result.

Additionally, the `pyproject.toml` file is updated to bump the version from `0.2.0` to `0.2.1`.