### PR TITLE
feat: Improve URL response handling

### DIFF
--- a/src/reducto/lib/helpers.py
+++ b/src/reducto/lib/helpers.py
@@ -25,7 +25,8 @@ class FullParseResponse(BaseModel):
 def handle_url_response(response: ParseResponse) -> FullParseResponse:
     if response.result.type == "url":
         with httpx.stream("GET", response.result.url) as r:
-            result = ResultFullResult.model_validate_json(r.text)
+            content = r.read().decode()
+            result = ResultFullResult.model_validate_json(content)
             return FullParseResponse(
                 duration=response.duration,
                 job_id=response.job_id,


### PR DESCRIPTION
Modify the `handle_url_response` function to read the response content
using `r.read().decode()` instead of `r.text`. This ensures that the
content is properly decoded, which is necessary for the
`ResultFullResult.model_validate_json` call to succeed.