### PR TITLE
fix(deps): remediate aiohttp vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,11 @@ Homepage = "https://github.com/reductoai/reducto-python-sdk"
 Repository = "https://github.com/reductoai/reducto-python-sdk"
 
 [project.optional-dependencies]
-aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
+aiohttp = [
+  "aiohttp>=3.13.4,<3.14; python_version < '3.10'",
+  "aiohttp>=3.14.2; python_version >= '3.10'",
+  "httpx_aiohttp>=0.1.9",
+]
 
 [tool.rye]
 managed = true

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -12,7 +12,7 @@
 -e file:.
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.13.5
     # via httpx-aiohttp
     # via reductoai
 aiosignal==1.4.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,7 +12,7 @@
 -e file:.
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.13.5
     # via httpx-aiohttp
     # via reductoai
 aiosignal==1.4.0


### PR DESCRIPTION
## Summary
- require aiohttp 3.13.4+ on Python 3.9
- require aiohttp 3.14.2+ on Python 3.10+
- refresh Rye lockfiles to aiohttp 3.13.5
- preserve the SDK's advertised Python 3.9 support

This supersedes #86: Vanta now flags aiohttp versions through 3.13.3, so a 3.13.3 floor is no longer sufficient.

## Validation
- `./scripts/test` (455 passed / 370 skipped; Pydantic v1: 452 passed / 373 skipped)
- `./scripts/lint`
- `rye build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reductoai/codesmith/reducto-python-sdk/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787776113&installation_model_id=5366&pr_number=106&repository=reductoai%2Freducto-python-sdk&return_to=https%3A%2F%2Fgithub.com%2Freductoai%2Freducto-python-sdk%2Fpull%2F106&signature=8b59ff2a54354c1fa2afd010e2a4f505da8ad7b1eba69a822d6148b3dd717a04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->